### PR TITLE
Add Tailscale Network Support and Audio Capture Task

### DIFF
--- a/cyclonedds.xml
+++ b/cyclonedds.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config">
+  <Domain>
+    <General>
+	<Interfaces>
+	  <NetworkInterface name="tailscale0" />
+	</Interfaces>
+      <AllowMulticast>false</AllowMulticast>
+    </General>
+    <Discovery>
+      <Peers>
+        <!-- On Device A, put Device B's Tailscale IP -->
+        <Peer address="100.96.130.58"/>
+      </Peers>
+      <ParticipantIndex>auto</ParticipantIndex>
+    </Discovery>
+  </Domain>
+</CycloneDDS>

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,6 +8,11 @@ preview = ["pixi-build"]
 [tasks]
 build = "colcon build --packages-select audio_tools --cmake-args -DCMAKE_BUILD_TYPE=Release"
 
+# Run the audio capture node and publish via tailscale
+run_audio_capture_tailscale = { cmd = [
+    "./setup_ros_tailscale.sh", "ros2", "run", "audio_tools", "audio_capture_node", "--ros-args", "-p", "sample_rate:=16000", "-p", "channels:=1", "-p", "sample_format:=S16LE"
+], depends-on = ["build"] }
+
 [target.win-64.tasks]
 vscode = "code ."
 
@@ -37,3 +42,4 @@ numpy = "*"
 [target.win-64.dependencies]
 python-devtools = "*"
 python = "*"
+

--- a/setup_ros_tailscale.sh
+++ b/setup_ros_tailscale.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Set up the network and DDS environment variables for Tailscale
+export CYCLONEDDS_URI=file://$PIXI_PROJECT_ROOT/cyclonedds.xml
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+export ROS_NETWORK_INTERFACE=tailscale0
+export ROS_IP=$(tailscale ip -4)
+export ROS_DOMAIN_ID=0
+
+# Source the ROS workspace
+source install/setup.bash
+
+# Execute the command passed as arguments
+exec "$@"
+
+echo "ROS2 environment configured for Tailscale communication"


### PR DESCRIPTION
This PR adds support for running ROS2 audio tools over Tailscale VPN by configuring CycloneDDS to properly use unicast communication. It also adds convenient Pixi tasks for running the audio capture node over Tailscale.

Changes

Added cyclonedds.xml to configure DDS for unicast communication over Tailscale
Created setup_ros_tailscale.sh script that sets up the proper environment variables
Added new Pixi task run_audio_capture_tailscale to easily run the audio capture node
Disabled multicast in CycloneDDS configuration to ensure proper unicast operation

Why these changes are needed
Tailscale uses a private network that doesn't support multicast, which is the default discovery mechanism for ROS2. These changes allow ROS2 nodes to properly discover each other and communicate over Tailscale by:

Forcing CycloneDDS to use unicast instead of multicast
Specifying the correct network interface for communication
Setting up all necessary environment variables automatically

Testing
Tested with multiple ROS2 nodes across different machines connected via Tailscale. Verified topic communication using ros2 topic echo and ros2 topic hz commands.